### PR TITLE
Replace Typeform's references by Aircall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# passport-typeform
-[![Build Status](https://travis-ci.com/anabellaspinelli/passport-typeform.svg?branch=master)](https://travis-ci.com/anabellaspinelli/passport-typeform)
+# passport-aircall
 
-[Passport](http://passportjs.org/) strategy for authenticating with [Typeform](https://www.typeform.com/)
+[Passport](http://passportjs.org/) strategy for authenticating with [Aircall](https://www.aircall.io/)
 using the OAuth 2.0 API.
 
-This module lets you authenticate using Typeform in your Node.js applications.
-By plugging into Passport, Typeform authentication can be easily and
+This module lets you authenticate using Aircall in your Node.js applications.
+By plugging into Passport, Aircall authentication can be easily and
 unobtrusively integrated into any application or framework that supports
 [Connect](http://www.senchalabs.org/connect/)-style middleware, including
 [Express](http://expressjs.com/).
@@ -13,44 +12,44 @@ unobtrusively integrated into any application or framework that supports
 ## Install
 
 ```bash
-$ npm install passport-typeform
+$ npm install passport-aircall
 ```
 
 ## Usage
 
 #### Create an Application
 
-Before using `passport-typeform`, you must register an application with Typeform.
-If you have not already done so, a new application can be created at
-[applications](https://admin.typeform.com/account#/section/apps) within
-Typeforms's account settings. Your application will be issued a client ID and client
-secret, which need to be provided to the strategy. You will also need to
+Before using `passport-aircall`, you must obtain OAuth credentation from Aircall.
+If you don't have them yet, please follow [this step ](https://developer.aircall.io/tutorials/how-aircall-oauth-flow-works/#1-get-your-oauth-credentials)
+of Aircall's tutorial.
+Aircall's team will issue a `client_id` and `client_secret`,
+which need to be provided to the strategy. You will also need to
 configure a callback URL which matches a route in your application.
 
 #### Configure Strategy
 
-The Typeform authentication strategy authenticates users using a Typeform account
-and OAuth 2.0 tokens. The client ID and secret obtained when creating an
-application are supplied as options when creating the strategy. The strategy
+The Aircal authentication strategy authenticates companies using an Aircall account
+and OAuth 2.0 tokens. The `client_id` and `client_secret` obtained before
+are supplied as options when creating the strategy. The strategy
 also requires a `verify` callback, which receives the access token and optional
-refresh token, as well as `profile` which contains the authenticated user's
-Typeform profile. The `verify` callback must call `cb` providing a user to
+refresh token, as well as `profile` which contains the authenticated company's
+Aircall profile. The `verify` callback must call `cb` providing a user to
 complete authentication.
 
 ```js
-var TypeformStrategy = require('passport-typeform').Strategy;
+var AircallStrategy = require('passport-aircall').Strategy;
 
 passport.use(
-  new TypeformStrategy(
+  new AircallStrategy(
     {
-      clientID: process.env.TYPEFORM_CLIENT_ID,
-      clientSecret: process.env.TYPEFORM_CLIENT_SECRET,
-      callbackURL: 'https://www.website.com/auth/typeform/callback',
-      scope: ['accounts:read'] // accounts:read is needed to fetch the user's profile, together with any other scope that you require
+      clientID: process.env.AIRCALL_CLIENT_ID,
+      clientSecret: process.env.AIRCALL_CLIENT_SECRET,
+      callbackURL: 'https://www.website.com/auth/aircall/callback',
+      scope: ['public_api'] // 'public_api' is a mandatory scope
     },
     function(accessToken, refreshToken, profile, cb) {
-      User.findOrCreate({ email: profile.email }, function(err, user) {
-        return cb(err, user);
+      Company.findOrCreate({ name: profile.name }, function(err, company) {
+        return cb(err, company);
       });
     }
   )
@@ -59,18 +58,18 @@ passport.use(
 
 #### Authenticate Requests
 
-Use `passport.authenticate()`, specifying the `'typeform'` strategy, to
+Use `passport.authenticate()`, specifying the `'aircall'` strategy, to
 authenticate requests.
 
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
 ```js
-app.get('/auth/typeform', passport.authenticate('typeform'));
+app.get('/auth/aircall', passport.authenticate('aircall'));
 
 app.get(
-  '/auth/typeform/callback',
-  passport.authenticate('typeform', { failureRedirect: '/login' }),
+  '/auth/aircall/callback',
+  passport.authenticate('aircall', { failureRedirect: '/login' }),
   function(req, res) {
     // Successful authentication, redirect home.
     res.redirect('/');
@@ -83,9 +82,9 @@ app.get(
 Developers using the popular [Express](http://expressjs.com/) web framework can
 refer to an [example](https://github.com/passport/express-4.x-facebook-example)
 as a starting point for their own web applications. The example shows how to
-authenticate users using Facebook. However, because both Facebook and Typeform
+authenticate users using Facebook. However, because both Facebook and Aircall
 use OAuth 2.0, the code is similar. Simply replace references to Facebook with
-corresponding references to Typeform.
+corresponding references to Aircall.
 
 ## Contributing
 
@@ -100,6 +99,8 @@ $ make test
 ```
 
 #### Coverage
+
+> Note: [Istanbul](https://github.com/gotwarlost/istanbul) package must be installed globally to run test coverage.
 
 The test suite covers 100% of the code base. All new feature development is
 expected to maintain that level. Coverage reports can be viewed by executing:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ configure a callback URL which matches a route in your application.
 
 #### Configure Strategy
 
-The Aircal authentication strategy authenticates companies using an Aircall account
+The Aircall authentication strategy authenticates companies using an Aircall account
 and OAuth 2.0 tokens. The `client_id` and `client_secret` obtained before
 are supplied as options when creating the strategy. The strategy
 also requires a `verify` callback, which receives the access token and optional

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -24,16 +24,15 @@ const API_VERSION = 'v1'
  *   - `clientID`      your Aircall application's Client ID
  *   - `clientSecret`  your Aircall application's Client Secret
  *   - `callbackURL`   URL to which Aircall will redirect the user after granting authorization
- *   - `scope`         array of permission scopes to request.  valid scopes include:
- *                     'user', 'public_repo', 'repo', 'gist', or none.
- *                     (see https://developer.typeform.com/get-started/scopes/ for more info)
+ *   - `scope`         array of permission scopes to request. As of August 2020, valid scopes only include 'public_api'.
+ *                     (see https://developer.aircall.io/api-references/#oauth-technology-partners for more info)
  *
  * Examples:
  *
  *     passport.use(new AircallStrategy({
  *         clientID: '123-456-789',
  *         clientSecret: 'shhh-its-a-secret'
- *         callbackURL: 'https://www.example.net/auth/typeform/callback',
+ *         callbackURL: 'https://www.example.net/auth/aircall/callback',
  *         userAgent: 'myapp.com'
  *       },
  *       function(accessToken, refreshToken, profile, cb) {
@@ -108,7 +107,7 @@ Strategy.prototype.userProfile = function (accessToken, done) {
           json = JSON.parse(err.data)
         } catch (_) {}
       }
-      
+
       if (json && json.error) {
         return done(new APIError(json.error, json.error_description))
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chai": "2.x.x",
     "chai-passport-strategy": "1.x.x",
     "make-node": "0.3.x",
-    "mocha": "1.x.x",
+    "mocha": "8.x.x",
     "proxyquire": "1.4.x"
   },
   "engines": {

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -4,7 +4,7 @@
 var Profile = require('../lib/profile'), fs = require('fs')
 
 describe('Profile.parse', function () {
-  describe('profile obtained from /me endpoint', function () {
+  describe('profile obtained from /company endpoint', function () {
     var profile
 
     before(function (done) {
@@ -19,9 +19,6 @@ describe('Profile.parse', function () {
 
     it('should parse profile', function () {
       expect(profile.company_name).to.equal('BeardyCompany')
-      // expect(profile.email).to.equal('beardy@typeform.com')
-      // expect(profile.language).to.equal('en')
-      // expect(profile.alias).to.equal('beardyman')
     })
   })
 })


### PR DESCRIPTION
## What does this PR do?

- Replace Typeform by Aircall in README
- Use `/company` endpoint for profile info
- Update `scope` comment to reflect the `public_api` mandatory scope
- Update **mocha** to `8.x.x`
